### PR TITLE
[FEAT] 토큰 기반 회원가입, 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,13 @@ dependencies {
 	//Webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	implementation 'commons-io:commons-io:2.11.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/recipe/backend/controller/RecipeScrapController.java
+++ b/src/main/java/com/recipe/backend/controller/RecipeScrapController.java
@@ -1,0 +1,81 @@
+//package com.recipe.backend.controller;
+//
+//import com.recipe.backend.dto.RecipeScrapDto;
+//import com.recipe.backend.service.RecipeScrapService;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.*;
+//
+//import java.util.List;
+//
+//@RestController
+//@RequestMapping("/api/recipes/scrap")
+//public class RecipeScrapController {
+//
+//    private final RecipeScrapService recipeScrapService;
+//
+//    public RecipeScrapController(RecipeScrapService recipeScrapService) {
+//        this.recipeScrapService = recipeScrapService;
+//    }
+//
+//    // ✅ 레시피 스크랩 추가 (이름만 요청)
+//    @PostMapping
+//    public ResponseEntity<String> scrapRecipe(@RequestParam String recipeName) {
+//        recipeScrapService.scrapRecipe(recipeName);
+//        return ResponseEntity.ok("레시피 스크랩 성공");
+//    }
+//
+//    // ✅ 레시피 스크랩 삭제
+//    @DeleteMapping
+//    public ResponseEntity<String> unScrapRecipe(@RequestParam String recipeName) {
+//        recipeScrapService.unScrapRecipe(recipeName);
+//        return ResponseEntity.ok("레시피 스크랩 취소 성공");
+//    }
+//
+//    // ✅ 사용자의 스크랩한 레시피 목록 조회
+//    @GetMapping
+//    public ResponseEntity<List<RecipeScrapDto>> getScrappedRecipes() {
+//        List<RecipeScrapDto> scrappedRecipes = recipeScrapService.getScrappedRecipes();
+//        return ResponseEntity.ok(scrappedRecipes);
+//    }
+//}
+
+package com.recipe.backend.controller;
+
+import com.recipe.backend.dto.RecipeScrapDto;
+import com.recipe.backend.service.RecipeScrapService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/recipes/scrap")
+public class RecipeScrapController {
+
+    private final RecipeScrapService recipeScrapService;
+
+    public RecipeScrapController(RecipeScrapService recipeScrapService) {
+        this.recipeScrapService = recipeScrapService;
+    }
+
+    // ✅ 레시피 스크랩 추가 (이름만 요청)
+    @PostMapping
+    public ResponseEntity<String> scrapRecipe(@RequestHeader("kakaoId") String kakaoId, @RequestParam String recipeName) {
+        recipeScrapService.scrapRecipe(kakaoId, recipeName);
+        return ResponseEntity.ok("레시피 스크랩 성공");
+    }
+
+    // ✅ 레시피 스크랩 삭제
+    @DeleteMapping
+    public ResponseEntity<String> unScrapRecipe(@RequestHeader("kakaoId") String kakaoId, @RequestParam String recipeName) {
+        recipeScrapService.unScrapRecipe(kakaoId, recipeName);
+        return ResponseEntity.ok("레시피 스크랩 취소 성공");
+    }
+
+    // ✅ 사용자의 스크랩한 레시피 목록 조회
+    @GetMapping
+    public ResponseEntity<List<RecipeScrapDto>> getScrappedRecipes(@RequestHeader("kakaoId") String kakaoId) {
+        List<RecipeScrapDto> scrappedRecipes = recipeScrapService.getScrappedRecipes(kakaoId);
+        return ResponseEntity.ok(scrappedRecipes);
+    }
+}

--- a/src/main/java/com/recipe/backend/controller/token/AuthController.java
+++ b/src/main/java/com/recipe/backend/controller/token/AuthController.java
@@ -1,0 +1,51 @@
+package com.recipe.backend.controller.token;
+
+import com.recipe.backend.dto.ResponseDTO;
+import com.recipe.backend.dto.token.LoginRequestDTO;
+import com.recipe.backend.util.token.JwtTokenProvider;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/login")
+@SecurityRequirement(name = "bearerAuth") // 🔥 스웨거에서 자동 인증 활성화
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @PostMapping
+    public ResponseEntity<ResponseDTO<Map<String, Object>>> login(@RequestBody LoginRequestDTO request) {
+        try {
+            // 사용자 인증
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(request.getUserId(), request.getPassword())
+            );
+
+            // JWT 발급
+            String token = jwtTokenProvider.generateToken(request.getUserId());
+            Map<String, Object> data = Map.of(
+                    "token", token,
+                    "userId", request.getUserId()
+            );
+
+            return ResponseEntity.ok(new ResponseDTO<>(200, "로그인 성공", data));
+        } catch (AuthenticationException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ResponseDTO<>(401, "로그인 실패: 아이디 또는 비밀번호를 확인하세요.", null));
+        }
+    }
+}

--- a/src/main/java/com/recipe/backend/controller/token/ScrapController.java
+++ b/src/main/java/com/recipe/backend/controller/token/ScrapController.java
@@ -1,0 +1,53 @@
+package com.recipe.backend.controller.token;
+
+import com.recipe.backend.dto.token.ScrapRecipeDto;
+import com.recipe.backend.service.token.ScrapService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/scraps")
+public class ScrapController {
+    private final ScrapService scrapService;
+
+    public ScrapController(ScrapService scrapService) {
+        this.scrapService = scrapService;
+    }
+
+    // 사용자가 스크랩한 레시피 목록 반환
+    @Operation(summary = "스크랩 조회", description = "로그인된 사용자의 스크랩 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<ScrapRecipeDto>> getScrapRecipes(Authentication authentication) {
+        String userId = authentication.getName(); // 현재 인증된 사용자의 ID 가져오기
+        return ResponseEntity.ok(scrapService.getScrapRecipes(userId));
+    }
+
+    // 레시피 이름으로 스크랩 추가
+    @Operation(summary = "스크랩 추가", description = "로그인된 사용자가 원하는 레시피를 스크랩합니다.")
+    @PostMapping("/{recipeName}")
+    public ResponseEntity<String> addScrapRecipe(
+            Authentication authentication,
+            @PathVariable String recipeName) {
+        String userId = authentication.getName(); // 현재 인증된 사용자의 ID 가져오기
+        boolean success = scrapService.addScrapRecipe(userId, recipeName);
+        if (success) {
+            return ResponseEntity.ok("레시피 스크랩 성공: " + recipeName);
+        }
+        return ResponseEntity.badRequest().body("레시피를 찾을 수 없거나 이미 스크랩됨: " + recipeName);
+    }
+
+    // 특정 레시피 삭제
+    @Operation(summary = "스크랩 삭제", description = "스크랩했던 레시피를 삭제합니다.")
+    @DeleteMapping("/{recipeName}")
+    public ResponseEntity<String> removeScrapRecipe(
+            Authentication authentication,
+            @PathVariable String recipeName) {
+        String userId = authentication.getName(); // 현재 인증된 사용자의 ID 가져오기
+        scrapService.removeScrapRecipe(userId, recipeName);
+        return ResponseEntity.ok("레시피 삭제됨: " + recipeName);
+    }
+}

--- a/src/main/java/com/recipe/backend/controller/token/UserApiController.java
+++ b/src/main/java/com/recipe/backend/controller/token/UserApiController.java
@@ -1,0 +1,56 @@
+package com.recipe.backend.controller.token;
+
+import com.recipe.backend.dto.ResponseDTO;
+import com.recipe.backend.dto.token.AddUserRequestDTO;
+import com.recipe.backend.service.token.TokenUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/signup")
+public class UserApiController {
+
+    private final TokenUserService tokenuserService;
+
+    @Operation(summary = "회원가입", description = "회원 정보를 입력받아 새 유저를 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "409", description = "중복된 사용자 ID"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping
+    public ResponseEntity<ResponseDTO<Map<String, Object>>> signup(@Valid @RequestBody AddUserRequestDTO request) {
+        if (tokenuserService.isUserIdDuplicated(request.getUserId())) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(new ResponseDTO<>(409, "이미 사용 중인 사용자 ID입니다.", null));
+        }
+
+        if (!request.getPassword().equals(request.getConfirmPassword())) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ResponseDTO<>(400, "비밀번호가 일치하지 않습니다.", null));
+        }
+
+        Long userId = tokenuserService.save(request);
+        Map<String, Object> data = Map.of(
+                "id", userId,
+                "username", request.getUsername(),
+                "userId", request.getUserId()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ResponseDTO<>(201, "회원가입 성공", data));
+    }
+}

--- a/src/main/java/com/recipe/backend/dto/RecipeScrapDto.java
+++ b/src/main/java/com/recipe/backend/dto/RecipeScrapDto.java
@@ -1,0 +1,34 @@
+package com.recipe.backend.dto;
+
+import java.util.List;
+
+public class RecipeScrapDto {
+    private Long id; // 스크랩 ID
+    private String recipeName;
+    private String ingredients;
+    private List<String> steps;
+
+    public RecipeScrapDto(Long id, String recipeName, String ingredients, List<String> steps) {
+        this.id = id;
+        this.recipeName = recipeName;
+        this.ingredients = ingredients;
+        this.steps = steps;
+    }
+
+    // Getter
+    public Long getId() {
+        return id;
+    }
+
+    public String getRecipeName() {
+        return recipeName;
+    }
+
+    public String getIngredients() {
+        return ingredients;
+    }
+
+    public List<String> getSteps() {
+        return steps;
+    }
+}

--- a/src/main/java/com/recipe/backend/dto/token/AddUserRequestDTO.java
+++ b/src/main/java/com/recipe/backend/dto/token/AddUserRequestDTO.java
@@ -1,0 +1,23 @@
+package com.recipe.backend.dto.token;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AddUserRequestDTO {
+    @NotBlank(message = "유저 이름은 필수입니다.")
+    private String username;
+
+    @NotBlank(message = "유저 ID는 필수입니다.")
+    private String userId;
+
+    @Size(min = 8, message = "비밀번호는 최소 8자리 이상이어야 합니다.") // 비밀번호는 8자리 이상으로 했어요
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+
+    @NotBlank(message = "비밀번호 확인은 필수입니다.")
+    private String confirmPassword;
+}

--- a/src/main/java/com/recipe/backend/dto/token/LoginRequestDTO.java
+++ b/src/main/java/com/recipe/backend/dto/token/LoginRequestDTO.java
@@ -1,0 +1,16 @@
+package com.recipe.backend.dto.token;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginRequestDTO {
+
+    @NotBlank(message = "유저 ID는 필수입니다.")
+    private String userId;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/recipe/backend/dto/token/LoginResponseDTO.java
+++ b/src/main/java/com/recipe/backend/dto/token/LoginResponseDTO.java
@@ -1,0 +1,11 @@
+package com.recipe.backend.dto.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponseDTO {
+    private String message;
+    private String token; // JWT 토큰 (JWT를 사용하는 경우)
+}

--- a/src/main/java/com/recipe/backend/dto/token/ScrapRecipeDto.java
+++ b/src/main/java/com/recipe/backend/dto/token/ScrapRecipeDto.java
@@ -1,0 +1,40 @@
+package com.recipe.backend.dto.token;
+
+import java.util.List;
+
+public class ScrapRecipeDto {
+    private String recipeName;  // 레시피 이름
+    private String ingredients; // 재료 정보
+    private List<String> steps; // 조리 단계
+
+    public ScrapRecipeDto(String recipeName, String ingredients, List<String> steps) {
+        this.recipeName = recipeName;
+        this.ingredients = ingredients;
+        this.steps = steps;
+    }
+
+    // Getter & Setter
+    public String getRecipeName() {
+        return recipeName;
+    }
+
+    public void setRecipeName(String recipeName) {
+        this.recipeName = recipeName;
+    }
+
+    public String getIngredients() {
+        return ingredients;
+    }
+
+    public void setIngredients(String ingredients) {
+        this.ingredients = ingredients;
+    }
+
+    public List<String> getSteps() {
+        return steps;
+    }
+
+    public void setSteps(List<String> steps) {
+        this.steps = steps;
+    }
+}

--- a/src/main/java/com/recipe/backend/entity/RecipeScrapEntity.java
+++ b/src/main/java/com/recipe/backend/entity/RecipeScrapEntity.java
@@ -1,0 +1,39 @@
+package com.recipe.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "recipe_scraps")
+public class RecipeScrapEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String recipeName;
+
+    @Column(nullable = false, length = 500)
+    private String ingredients;
+
+    @ElementCollection
+    @CollectionTable(name = "recipe_scrap_steps", joinColumns = @JoinColumn(name = "recipe_scrap_id"))
+    @Column(name = "step")
+    private List<String> steps;
+
+    @Column(nullable = false)
+    private String userId; // 사용자 ID
+
+    public RecipeScrapEntity(String userId, String recipeName, String ingredients, List<String> steps) {
+        this.userId = userId;
+        this.recipeName = recipeName;
+        this.ingredients = ingredients;
+        this.steps = steps;
+    }
+}

--- a/src/main/java/com/recipe/backend/entity/token/TokenUserEntity.java
+++ b/src/main/java/com/recipe/backend/entity/token/TokenUserEntity.java
@@ -1,0 +1,92 @@
+package com.recipe.backend.entity.token;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+@Entity
+@Table(name = "users") // 테이블명
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 기본 생성자 보호
+public class TokenUserEntity implements UserDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // 기본키 자동 생성
+    @Column(name = "id", updatable = false, nullable = false)
+    private Long id;
+
+    @Column(name = "username", nullable = false)
+    private String username; // 유저 이름
+
+    @Column(name = "user_id", nullable = false, unique = true)
+    private String userId; // 유저가 설정하는 고유 ID (로그인용)
+
+    @Column(name = "password", nullable = false)
+    private String password; // 비밀번호 (암호화 필요)
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt; // 생성 일자
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt; // 수정 일자
+
+    @Builder
+    public TokenUserEntity(String username, String userId, String password) {
+        this.username = username;
+        this.userId = userId;
+        this.password = password;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(() -> "ROLE_USER"); // 기본 권한 부여
+    }
+
+    @Override
+    public String getUsername() {
+        return this.userId; // 로그인 시 사용되는 ID
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/recipe/backend/filter/token/JwtAuthenticationFilter.java
+++ b/src/main/java/com/recipe/backend/filter/token/JwtAuthenticationFilter.java
@@ -1,0 +1,41 @@
+package com.recipe.backend.filter.token;
+
+import com.recipe.backend.util.token.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider; // 주입받는 JwtTokenProvider
+    private final UserDetailsService userDetailsService; // 주입받는 UserDetailsService
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws java.io.IOException, jakarta.servlet.ServletException {
+        String token = resolveToken(request);
+        if (token != null && jwtTokenProvider.validateToken(token) != null) {
+            String userId = jwtTokenProvider.validateToken(token);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+            );
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/recipe/backend/repository/RecipeScrapRepository.java
+++ b/src/main/java/com/recipe/backend/repository/RecipeScrapRepository.java
@@ -1,0 +1,14 @@
+package com.recipe.backend.repository;
+
+import com.recipe.backend.entity.RecipeScrapEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RecipeScrapRepository extends JpaRepository<RecipeScrapEntity, Long> {
+    List<RecipeScrapEntity> findByUserId(String userId);
+    boolean existsByUserIdAndRecipeName(String userId, String recipeName);
+    void deleteByUserIdAndRecipeName(String userId, String recipeName);
+}

--- a/src/main/java/com/recipe/backend/repository/token/TokenUserRepository.java
+++ b/src/main/java/com/recipe/backend/repository/token/TokenUserRepository.java
@@ -1,0 +1,11 @@
+package com.recipe.backend.repository.token;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TokenUserRepository extends JpaRepository<com.recipe.backend.entity.token.TokenUserEntity, Long> {
+    Optional<com.recipe.backend.entity.token.TokenUserEntity> findByUserId(String userId); // user_id로 검색
+
+    boolean existsByUserId(String userId);
+}

--- a/src/main/java/com/recipe/backend/service/RecipeScrapService.java
+++ b/src/main/java/com/recipe/backend/service/RecipeScrapService.java
@@ -1,0 +1,134 @@
+//package com.recipe.backend.service;
+//
+//import com.recipe.backend.dto.RecipeDto;
+//import com.recipe.backend.dto.RecipeScrapDto;
+//import com.recipe.backend.entity.RecipeScrapEntity;
+//import com.recipe.backend.repository.RecipeScrapRepository;
+//import jakarta.transaction.Transactional;
+//import org.springframework.security.core.Authentication;
+//import org.springframework.security.core.context.SecurityContextHolder;
+//import org.springframework.stereotype.Service;
+//
+//import java.util.List;
+//import java.util.Optional;
+//import java.util.stream.Collectors;
+//
+//@Service
+//public class RecipeScrapService {
+//
+//    private final RecipeScrapRepository recipeScrapRepository;
+//    private final RecipeService recipeService;
+//
+//    public RecipeScrapService(RecipeScrapRepository recipeScrapRepository, RecipeService recipeService) {
+//        this.recipeScrapRepository = recipeScrapRepository;
+//        this.recipeService = recipeService;
+//    }
+//
+//    // ✅ 레시피 스크랩 추가 (이름만 받아와서 자동 저장)
+//    public void scrapRecipe(String recipeName) {
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//        String userId = authentication.getName(); // 현재 로그인한 사용자 ID
+//
+//        // 이미 스크랩한 레시피인지 확인
+//        if (recipeScrapRepository.existsByUserIdAndRecipeName(userId, recipeName)) {
+//            throw new IllegalStateException("이미 스크랩한 레시피입니다.");
+//        }
+//
+//        // 레시피 데이터 조회
+//        Optional<RecipeDto> recipeData = recipeService.fetchRecipes()
+//                .stream()
+//                .filter(recipe -> recipe.getRecipeName().equalsIgnoreCase(recipeName))
+//                .findFirst();
+//
+//        // 레시피가 존재하면 저장
+//        if (recipeData.isPresent()) {
+//            RecipeDto recipe = recipeData.get();
+//            RecipeScrapEntity scrap = new RecipeScrapEntity(userId, recipe.getRecipeName(), recipe.getIngredients(), recipe.getSteps());
+//            recipeScrapRepository.save(scrap);
+//        } else {
+//            throw new IllegalArgumentException("해당 레시피를 찾을 수 없습니다.");
+//        }
+//    }
+//
+//    // ✅ 레시피 스크랩 삭제
+//    @Transactional
+//    public void unScrapRecipe(String recipeName) {
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//        String userId = authentication.getName();
+//
+//        recipeScrapRepository.deleteByUserIdAndRecipeName(userId, recipeName);
+//    }
+//
+//    // ✅ 사용자의 스크랩한 레시피 목록 조회
+//    public List<RecipeScrapDto> getScrappedRecipes() {
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//        String userId = authentication.getName();
+//
+//        return recipeScrapRepository.findByUserId(userId)
+//                .stream()
+//                .map(scrap -> new RecipeScrapDto(scrap.getId(), scrap.getRecipeName(), scrap.getIngredients(), scrap.getSteps()))
+//                .collect(Collectors.toList());
+//    }
+//}
+
+package com.recipe.backend.service;
+
+import com.recipe.backend.dto.RecipeDto;
+import com.recipe.backend.dto.RecipeScrapDto;
+import com.recipe.backend.entity.RecipeScrapEntity;
+import com.recipe.backend.repository.RecipeScrapRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class RecipeScrapService {
+
+    private final RecipeScrapRepository recipeScrapRepository;
+    private final RecipeService recipeService;
+
+    public RecipeScrapService(RecipeScrapRepository recipeScrapRepository, RecipeService recipeService) {
+        this.recipeScrapRepository = recipeScrapRepository;
+        this.recipeService = recipeService;
+    }
+
+    // ✅ 레시피 스크랩 추가 (사용자 ID를 헤더에서 받음)
+    public void scrapRecipe(String kakaoId, String recipeName) {
+        // 이미 스크랩한 레시피인지 확인
+        if (recipeScrapRepository.existsByUserIdAndRecipeName(kakaoId, recipeName)) {
+            throw new IllegalStateException("이미 스크랩한 레시피입니다.");
+        }
+
+        // 레시피 데이터 조회
+        Optional<RecipeDto> recipeData = recipeService.fetchRecipes()
+                .stream()
+                .filter(recipe -> recipe.getRecipeName().equalsIgnoreCase(recipeName))
+                .findFirst();
+
+        // 레시피가 존재하면 저장
+        if (recipeData.isPresent()) {
+            RecipeDto recipe = recipeData.get();
+            RecipeScrapEntity scrap = new RecipeScrapEntity(kakaoId, recipe.getRecipeName(), recipe.getIngredients(), recipe.getSteps());
+            recipeScrapRepository.save(scrap);
+        } else {
+            throw new IllegalArgumentException("해당 레시피를 찾을 수 없습니다.");
+        }
+    }
+
+    // ✅ 레시피 스크랩 삭제 (사용자 ID 헤더에서 받음)
+    @Transactional
+    public void unScrapRecipe(String kakaoId, String recipeName) {
+        recipeScrapRepository.deleteByUserIdAndRecipeName(kakaoId, recipeName);
+    }
+
+    // ✅ 사용자의 스크랩한 레시피 목록 조회
+    public List<RecipeScrapDto> getScrappedRecipes(String kakaoId) {
+        return recipeScrapRepository.findByUserId(kakaoId)
+                .stream()
+                .map(scrap -> new RecipeScrapDto(scrap.getId(), scrap.getRecipeName(), scrap.getIngredients(), scrap.getSteps()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/recipe/backend/service/token/ScrapService.java
+++ b/src/main/java/com/recipe/backend/service/token/ScrapService.java
@@ -1,0 +1,54 @@
+package com.recipe.backend.service.token;
+
+import com.recipe.backend.dto.RecipeDto;
+import com.recipe.backend.dto.token.ScrapRecipeDto;
+import com.recipe.backend.service.RecipeService;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class ScrapService {
+    private final Map<String, List<ScrapRecipeDto>> userScrapRecipes = new HashMap<>();
+    private final RecipeService recipeService; // 기존 레시피 API 호출을 위한 의존성 추가
+
+    public ScrapService(RecipeService recipeService) {
+        this.recipeService = recipeService;
+    }
+
+    // 사용자별 스크랩 추가
+    public boolean addScrapRecipe(String userId, String recipeName) {
+        // 기존 API에서 레시피 정보를 검색
+        Optional<RecipeDto> recipeOpt = recipeService.fetchRecipes()
+                .stream()
+                .filter(r -> r.getRecipeName().equals(recipeName))
+                .findFirst();
+
+        if (recipeOpt.isPresent()) {
+            RecipeDto recipe = recipeOpt.get();
+            ScrapRecipeDto scrapRecipe = new ScrapRecipeDto(recipe.getRecipeName(), recipe.getIngredients(), recipe.getSteps());
+
+            // 사용자의 스크랩 목록 가져오기
+            userScrapRecipes.putIfAbsent(userId, new ArrayList<>());
+            List<ScrapRecipeDto> userScraps = userScrapRecipes.get(userId);
+
+            // 중복 방지 후 추가
+            if (userScraps.stream().noneMatch(r -> r.getRecipeName().equals(recipeName))) {
+                userScraps.add(scrapRecipe);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // 사용자별 스크랩 목록 가져오기
+    public List<ScrapRecipeDto> getScrapRecipes(String userId) {
+        return userScrapRecipes.getOrDefault(userId, new ArrayList<>());
+    }
+
+    // 사용자별 특정 레시피 삭제
+    public void removeScrapRecipe(String userId, String recipeName) {
+        userScrapRecipes.getOrDefault(userId, new ArrayList<>())
+                .removeIf(recipe -> recipe.getRecipeName().equals(recipeName));
+    }
+}

--- a/src/main/java/com/recipe/backend/service/token/TokenUserDetailServiceImpl.java
+++ b/src/main/java/com/recipe/backend/service/token/TokenUserDetailServiceImpl.java
@@ -1,0 +1,21 @@
+package com.recipe.backend.service.token;
+
+import com.recipe.backend.repository.token.TokenUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TokenUserDetailServiceImpl implements UserDetailsService {
+
+    private final TokenUserRepository tokenuserRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        return tokenuserRepository.findByUserId(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + userId));
+    }
+}

--- a/src/main/java/com/recipe/backend/service/token/TokenUserService.java
+++ b/src/main/java/com/recipe/backend/service/token/TokenUserService.java
@@ -1,0 +1,31 @@
+package com.recipe.backend.service.token;
+
+
+import com.recipe.backend.dto.token.AddUserRequestDTO;
+import com.recipe.backend.repository.token.TokenUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TokenUserService {
+
+    private final TokenUserRepository tokenuserRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public Long save(AddUserRequestDTO request) {
+        return tokenuserRepository.save(
+                com.recipe.backend.entity.token.TokenUserEntity.builder()
+                        .username(request.getUsername())
+                        .userId(request.getUserId())
+                        .password(bCryptPasswordEncoder.encode(request.getPassword()))
+                        .build()
+        ).getId();
+    }
+
+    // 사용자 ID 중복 확인
+    public boolean isUserIdDuplicated(String userId) {
+        return tokenuserRepository.existsByUserId(userId);
+    }
+}

--- a/src/main/java/com/recipe/backend/util/token/JwtTokenProvider.java
+++ b/src/main/java/com/recipe/backend/util/token/JwtTokenProvider.java
@@ -1,0 +1,42 @@
+package com.recipe.backend.util.token;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private static final String SECRET_KEY = "your-secure-secret-key-for-jwt-signing";
+    private static final long EXPIRATION_TIME = 86400000; // 24시간
+
+    private final Key key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+
+    public String generateToken(String userId) {
+        return Jwts.builder()
+                .setSubject(userId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String validateToken(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return claims.getSubject();
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new RuntimeException("유효하지 않은 토큰입니다.");
+        }
+    }
+}


### PR DESCRIPTION
## ⛓️ 연관된 이슈
<!-- ex) #이슈번호, close#이슈번호 -->
close #17 
close #8 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요-->
카카오 로그인 DB저장까지는 잘되는데 스크랩 기능과 연결할  때 사용자별로 저장이 잘 안되서
카카오 로그인 말고 일단 토큰기반으로 회원가입, 로그인 과 스크랩 기능 구현했습니다.

## 📷 스크린샷
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요-->
![image](https://github.com/user-attachments/assets/a1e42f2f-1ce4-4795-8ae8-507a63534135)


## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
