### PR TITLE
[FIX] 로그인 조건 추가, 냉장고 조회 로직 수정

### DIFF
--- a/src/main/java/com/recipe/backend/config/SecurityConfig.java
+++ b/src/main/java/com/recipe/backend/config/SecurityConfig.java
@@ -43,15 +43,12 @@ public class SecurityConfig {
                         "/api/**",
                         "/api/recipes/**",
                         "/api/camera/open",
-                        "/api/fridge/{userId}",
                         "/api/ingredients/list",
-                        "/api/fridge/add",
-                        "/api/fridge/**",
                         "/api/login",
                         "/api/signup/**",
                         "/api/recipes/recommend/{userId}"
                 ).permitAll()
-                .requestMatchers("/api/scrap/**").authenticated() // 🔥 인증된 사용자만 사용 가능
+                .requestMatchers("/api/scrap/**","/api/fridge/**").authenticated() // 🔥 인증된 사용자만 사용 가능
                 .anyRequest().authenticated()
         );
 

--- a/src/main/java/com/recipe/backend/config/SecurityConfig.java
+++ b/src/main/java/com/recipe/backend/config/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
                         "/api/signup/**",
                         "/api/recipes/recommend/{userId}"
                 ).permitAll()
-                .requestMatchers("/api/scrap/**","/api/fridge/**").authenticated() // 🔥 인증된 사용자만 사용 가능
+                .requestMatchers("/api/fridge/**").authenticated()
+                .requestMatchers("/api/scrap/**").authenticated() // 🔥 인증된 사용자만 사용 가능
                 .anyRequest().authenticated()
         );
 

--- a/src/main/java/com/recipe/backend/controller/IngredientController.java
+++ b/src/main/java/com/recipe/backend/controller/IngredientController.java
@@ -1,6 +1,7 @@
 package com.recipe.backend.controller;
 
-import com.recipe.backend.service.*;
+
+import com.recipe.backend.service.IngredientService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/recipe/backend/controller/UserFridgeController.java
+++ b/src/main/java/com/recipe/backend/controller/UserFridgeController.java
@@ -1,10 +1,13 @@
 package com.recipe.backend.controller;
 
-import com.recipe.backend.entity.*;
-import com.recipe.backend.service.*;
-import com.recipe.backend.dto.*;
+
+import com.recipe.backend.dto.AddIngredientsRequest;
+import com.recipe.backend.dto.AddIngredientsResponse;
+import com.recipe.backend.entity.UserFridge;
+import com.recipe.backend.service.UserFridgeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,6 +20,7 @@ import static org.springframework.http.ResponseEntity.*;
 @RestController
 @RequestMapping("/api/fridge")
 @Tag(name = "User Fridge API", description = "사용자의 냉장고 관리 API")
+@SecurityRequirement(name = "JWT TOKEN")
 public class UserFridgeController {
 
     private final UserFridgeService userFridgeService;
@@ -33,9 +37,12 @@ public class UserFridgeController {
     }
 
     @PostMapping
-    @Operation(summary = "냉장고에 재료 추가", description = "특정 사용자의 냉장고에 하나의 재료를 추가합니다.")
+    @Operation(summary = "냉장고에 재료 추가", description = "고정 재료에 없는 새로운 재료를 추가합니다. 이미 존재하는 재료는 추가되지 않습니다.")
     public ResponseEntity<?> addIngredientToFridge(@RequestParam String ingredientName, @RequestParam Long userId) {
         try {
+            if (userFridgeService.isIngredientAlreadyInFridge(ingredientName, userId)) {
+                return status(HttpStatus.BAD_REQUEST).body("Ingredient already exists in the user's fridge");
+            }
             UserFridge savedIngredient = userFridgeService.addIngredientToFridge(ingredientName, userId);
             return ok(savedIngredient);
         } catch (IllegalArgumentException e) {
@@ -43,22 +50,35 @@ public class UserFridgeController {
         }
     }
 
-
     @PostMapping(
             value = "/add",
             consumes = "application/json",
             produces = "application/json"
     )
-    @Operation(summary = "냉장고에 여러 재료 추가", description = "특정 사용자의 냉장고에 여러 재료를 한 번에 추가합니다.")
+    @Operation(summary = "냉장고에 여러 재료 추가", description = "고정 재료 목록에서만 선택하여 여러 재료를 추가합니다. 이미 존재하는 재료는 추가되지 않습니다.")
     public ResponseEntity<AddIngredientsResponse> addIngredientsToFridge(@RequestBody AddIngredientsRequest request) {
         try {
-            List<UserFridge> savedIngredients = userFridgeService.addIngredientsToFridge(request.getUserId(), request.getIngredients());
+            List<String> fixedIngredients = userFridgeService.getFixedIngredients();
+
+            // 유효한 재료만 필터링
+            List<String> validIngredients = request.getIngredients().stream()
+                    .filter(fixedIngredients::contains)
+                    .toList();
+
+            if (validIngredients.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(new AddIngredientsResponse("재료 목록에 없습니다. 카메라로 인식 후 추가하세요.", null));
+            }
+
+            // 필터링된 재료만 추가
+            List<UserFridge> savedIngredients = userFridgeService.addIngredientsToFridge(request.getUserId(), validIngredients);
             AddIngredientsResponse response = new AddIngredientsResponse("재료가 추가되었습니다.", savedIngredients);
-            return ResponseEntity.ok().body(response); // JSON 응답 명시
+            return ResponseEntity.ok().body(response);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new AddIngredientsResponse(e.getMessage(), null));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new AddIngredientsResponse("An unexpected error occurred", null));
         }
     }
+
 }

--- a/src/main/java/com/recipe/backend/controller/UserFridgeController.java
+++ b/src/main/java/com/recipe/backend/controller/UserFridgeController.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import static org.springframework.http.ResponseEntity.*;
 
-@CrossOrigin(origins = "http://localhost:8080")
+
 @RestController
 @RequestMapping("/api/fridge")
 @Tag(name = "User Fridge API", description = "사용자의 냉장고 관리 API")
@@ -30,14 +30,14 @@ public class UserFridgeController {
     }
 
     @GetMapping("/{userId}")
-    @Operation(summary = "사용자의 냉장고 조회", description = "특정 사용자의 냉장고에 저장된 재료 목록을 반환합니다.")
+    @Operation(summary = "사용자의 냉장고 조회", description = "특정 사용자의 냉장고에 저장된 재료 목록을 반환합니다.",security = @SecurityRequirement(name = "JWT TOKEN"))
     public ResponseEntity<List<UserFridge>> getUserFridge(@PathVariable Long userId) {
         List<UserFridge> fridgeContents = userFridgeService.getUserFridge(userId);
         return ok(fridgeContents);
     }
 
     @PostMapping
-    @Operation(summary = "냉장고에 재료 추가", description = "고정 재료에 없는 새로운 재료를 추가합니다. 이미 존재하는 재료는 추가되지 않습니다.")
+    @Operation(summary = "냉장고에 재료 추가", description = "고정 재료에 없는 새로운 재료를 추가합니다. 이미 존재하는 재료는 추가되지 않습니다.",security = @SecurityRequirement(name = "JWT TOKEN"))
     public ResponseEntity<?> addIngredientToFridge(@RequestParam String ingredientName, @RequestParam Long userId) {
         try {
             if (userFridgeService.isIngredientAlreadyInFridge(ingredientName, userId)) {
@@ -55,7 +55,7 @@ public class UserFridgeController {
             consumes = "application/json",
             produces = "application/json"
     )
-    @Operation(summary = "냉장고에 여러 재료 추가", description = "고정 재료 목록에서만 선택하여 여러 재료를 추가합니다. 이미 존재하는 재료는 추가되지 않습니다.")
+    @Operation(summary = "냉장고에 여러 재료 추가", description = "고정 재료 목록에서만 선택하여 여러 재료를 추가합니다. 이미 존재하는 재료는 추가되지 않습니다.",security = @SecurityRequirement(name = "JWT TOKEN"))
     public ResponseEntity<AddIngredientsResponse> addIngredientsToFridge(@RequestBody AddIngredientsRequest request) {
         try {
             List<String> fixedIngredients = userFridgeService.getFixedIngredients();

--- a/src/main/java/com/recipe/backend/dto/AddIngredientsResponse.java
+++ b/src/main/java/com/recipe/backend/dto/AddIngredientsResponse.java
@@ -1,6 +1,8 @@
 package com.recipe.backend.dto;
 
-import com.recipe.backend.entity.*;
+
+import com.recipe.backend.entity.UserFridge;
+
 import java.util.List;
 
 public class AddIngredientsResponse {

--- a/src/main/java/com/recipe/backend/repository/IngredientRepository.java
+++ b/src/main/java/com/recipe/backend/repository/IngredientRepository.java
@@ -1,6 +1,7 @@
 package com.recipe.backend.repository;
 
-import com.recipe.backend.entity.*;
+
+import com.recipe.backend.entity.Ingredient;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/recipe/backend/repository/UserFridgeRepository.java
+++ b/src/main/java/com/recipe/backend/repository/UserFridgeRepository.java
@@ -1,6 +1,7 @@
 package com.recipe.backend.repository;
 
-import com.recipe.backend.entity.*;
+
+import com.recipe.backend.entity.UserFridge;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/recipe/backend/service/UserFridgeService.java
+++ b/src/main/java/com/recipe/backend/service/UserFridgeService.java
@@ -1,8 +1,8 @@
 package com.recipe.backend.service;
 
-import com.recipe.backend.entity.*;
-import com.recipe.backend.repository.*;
-import com.recipe.backend.service.*;
+
+import com.recipe.backend.entity.UserFridge;
+import com.recipe.backend.repository.UserFridgeRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -22,6 +22,11 @@ public class UserFridgeService {
         return userFridgeRepository.findByUserId(userId);
     }
 
+    public boolean isIngredientAlreadyInFridge(String ingredientName, Long userId) {
+        return userFridgeRepository.existsByIngredientNameAndUserId(ingredientName, userId);
+    }
+
+
     public UserFridge addIngredientToFridge(String ingredientName, Long userId) {
         if (!userFridgeRepository.existsByIngredientNameAndUserId(ingredientName, userId)) {
             return userFridgeRepository.save(new UserFridge(ingredientName, userId));
@@ -39,6 +44,15 @@ public class UserFridgeService {
             }
         }
         return savedIngredients;
+    }
+
+    public List<String> getFixedIngredients() {
+        return List.of(
+                "애호박", "당근", "오이", "돼지고기", "생선",
+                "계란", "고추", "양배추", "양파", "마늘",
+                "김치", "새우", "버섯", "햄", "두부",
+                "빵", "스파게티면"
+        );
     }
 }
 


### PR DESCRIPTION
## ⛓️ 연관된 이슈
<!-- ex) #19 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요-->
로그인 조건 추가, 냉장고 조회 로직 수정


## 📷 스크린샷
![image](https://github.com/user-attachments/assets/b585b2bd-87f1-49da-9eb7-23e55087bc68)
중복 재료는 추가 못하게 하고 /add api는 고정 재료 리스트에서만 추가하도록 수정
![image](https://github.com/user-attachments/assets/7e72e3ff-8490-463f-88dc-ef2cd9e5b557)
![화면 캡처 2025-02-05 221107](https://github.com/user-attachments/assets/b4878893-29f4-4175-8110-b992a60823a7)
![화면 캡처 2025-02-05 221122](https://github.com/user-attachments/assets/b6a56fe0-9c6a-4913-9ba3-8e6578de7dcb)



## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
